### PR TITLE
Fix isCtrlEnter switch

### DIFF
--- a/js/form.js
+++ b/js/form.js
@@ -13,6 +13,7 @@ class Form {
       this._categoryLaunch = options.categoryLaunch;
       this._clearPreview = this._clearPreview.bind(this);
       this._handleInput = this._handleInput.bind(this);
+      this._handleKeyup = this._handleKeyup.bind(this);
       this._handleKeydown = this._handleKeydown.bind(this);
       this._previewValue = this._previewValue.bind(this);
       this._submitForm = this._submitForm.bind(this);
@@ -94,8 +95,11 @@ class Form {
       if (isCategoryLaunch) this._categoryLaunch();
       if (this._instantRedirect && isKey) this._submitWithValue(newQuery);
     }
-  
-  
+
+    _handleKeyup(e) {
+      if ($.key(e) == 'ctrl') this.isCtrlEnter = false;
+    }
+
     _handleKeydown(e) {
       if ($.isUp(e) || $.isDown(e) || $.isRemove(e)) return;
       
@@ -132,6 +136,7 @@ class Form {
     }
   
     _registerEvents() {
+      document.addEventListener('keyup', this._handleKeyup);
       document.addEventListener('keydown', this._handleKeydown);
       this._inputEl.addEventListener('input', this._handleInput);
       this._formEl.addEventListener('submit', this._submitForm, false);


### PR DESCRIPTION
When CONFIG.newTab = true and two requests are executed: the first with a clamped ctrl, and the second without, then the resulting page will be with the string ".com" at the end. This has now been fixed.